### PR TITLE
Update codebase to py-algorand-sdk 1.7.0

### DIFF
--- a/algonim.py
+++ b/algonim.py
@@ -64,8 +64,9 @@ def main():
             f.close()
         match_data = msgpack.unpackb(match_data_bytes)
 
-        opponent = {'pk': mnemonic.to_public_key(args['<opponent_mnemonic>']),
-                    'sk': mnemonic.to_private_key(args['<opponent_mnemonic>'])}
+        opponent_private_key = mnemonic.to_private_key(args['<opponent_mnemonic>'])
+        opponent = {'pk': address_from_private_key(opponent_private_key),
+                    'sk': opponent_private_key}
         microalgo_bet_amount = match_data['microalgo_bet_amount']
 
         print("                                                               ")
@@ -161,8 +162,9 @@ def main():
             match_data_bytes = f.read()
             f.close()
         match_data = msgpack.unpackb(match_data_bytes)
-        player = {'pk': mnemonic.to_public_key(args['<player_mnemonic>']),
-                  'sk': mnemonic.to_private_key(args['<player_mnemonic>'])}
+        player_private_key = mnemonic.to_private_key(args['<player_mnemonic>'])
+        player = {'pk': address_from_private_key(player_private_key),
+                  'sk': player_private_key}
         asa_pieces_amount = int(args['<asa_pieces_amount>'])
 
         asa_pieces_id = match_data['asa_pieces_id']

--- a/algonim_moves.py
+++ b/algonim_moves.py
@@ -1,6 +1,7 @@
 import msgpack
 import base64
 from algosdk import encoding, mnemonic, transaction
+from algosdk.account import address_from_private_key
 from algonim_asa import *
 from algonim_asc1 import *
 
@@ -121,8 +122,9 @@ def match_setup(algod_client, dealer_passphrase, addr_opponent,
 
     # AlgoNim Players
     # Palyer 1 (Dealer) - Match Set Up costs about: 0.8 ALGO
-    dealer = {'pk': mnemonic.to_public_key(dealer_passphrase),
-              'sk': mnemonic.to_private_key(dealer_passphrase)}
+    dealer_private_key = mnemonic.to_private_key(dealer_passphrase)
+    dealer = {'pk': address_from_private_key(dealer_private_key),
+              'sk': dealer_private_key}
 
     # Player 2 (Opponent) - Must Opt-In AlgoNim ASAs to play the match
     opponent = {'pk': addr_opponent}


### PR DESCRIPTION
`mnemonic.to_public_key()` is deprecated